### PR TITLE
Coerce numeric actor attributes and migrate item descriptions

### DIFF
--- a/coc7/models/actor/document-class.js
+++ b/coc7/models/actor/document-class.js
@@ -4547,6 +4547,24 @@ export default class CoC7ModelsActorDocumentClass extends Actor {
    * @returns {object}
    */
   static migrateData (source) {
+    const coerceAttribNumber = (path, { computeAuto = false } = {}) => {
+      const value = foundry.utils.getProperty(source, path)
+      if (typeof value === 'undefined' || value === null) return
+      if (value === 'auto') {
+        if (computeAuto) {
+          const computedValue = computeAuto()
+          if (typeof computedValue !== 'undefined') {
+            foundry.utils.setProperty(source, path, computedValue)
+          }
+        }
+        return
+      }
+      const numericValue = Number(value)
+      if (!Number.isNaN(numericValue)) {
+        foundry.utils.setProperty(source, path, numericValue)
+      }
+    }
+
     if (source.type === 'vehicle') {
       // Move vehicle attribs to vehicle stats
       if (typeof source.system?.description?.notes !== 'undefined' && typeof source.system?.description?.keeper === 'undefined') {
@@ -4573,6 +4591,28 @@ export default class CoC7ModelsActorDocumentClass extends Actor {
       if (typeof source.system?.attribs?.armor?.locations !== 'undefined' && typeof source.system?.stats?.armor?.locations === 'undefined') {
         foundry.utils.setProperty(source, 'system.stats.armor.locations', source.system.attribs.armor.locations)
       }
+      coerceAttribNumber('system.stats.hp')
+      coerceAttribNumber('system.stats.mov')
+      coerceAttribNumber('system.stats.build.value')
+      coerceAttribNumber('system.stats.build.current')
+      coerceAttribNumber('system.stats.armor.value')
+    }
+    if (['character', 'npc', 'creature'].includes(source.type)) {
+      coerceAttribNumber('system.attribs.hp.value')
+      coerceAttribNumber('system.attribs.hp.max')
+      coerceAttribNumber('system.attribs.mp.value')
+      coerceAttribNumber('system.attribs.mp.max')
+      coerceAttribNumber('system.attribs.lck.value')
+      coerceAttribNumber('system.attribs.san.value')
+      coerceAttribNumber('system.attribs.san.max')
+      coerceAttribNumber('system.attribs.san.dailyLoss')
+      coerceAttribNumber('system.attribs.san.dailyLimit')
+      coerceAttribNumber('system.attribs.mov.value', {
+        computeAuto: () => CoC7ModelsActorDocumentClass.movFromCharacteristics(source.system?.characteristics ?? {}, source.type, source.system?.infos?.age)
+      })
+      coerceAttribNumber('system.attribs.build.value', {
+        computeAuto: () => CoC7ModelsActorDocumentClass.buildFromCharacteristics(source.system?.characteristics ?? {})
+      })
     }
     // Migrate status to conditions
     if (['character', 'npc', 'creature'].includes(source.type) && typeof source.system?.status !== 'undefined' && typeof source.system?.conditions === 'undefined') {

--- a/coc7/models/item/item-system.js
+++ b/coc7/models/item/item-system.js
@@ -51,9 +51,11 @@ export default class CoC7ModelsItemItemSystem extends CoC7ModelsItemGlobalSystem
    * @returns {object}
    */
   static migrateData (source) {
-    // Migrate description to object
+    // Migrate description from string to object
     if (typeof source.description === 'string') {
-      foundry.utils.setProperty(source, 'description.value', source.description)
+      const oldDesc = source.description
+      delete source.description 
+      foundry.utils.setProperty(source, 'description.value', oldDesc)
     }
     return super.migrateData(source)
   }


### PR DESCRIPTION
## Fix data migration crashes for item description and improve numeric attribute coercion

## Description
This PR try to fixes two important data migration issues in the CoC7 system:

1. **Fixed critical migration error in `CoC7ModelsItemItemSystem`**  
   The previous `migrateData` logic would throw `TypeError: Cannot create property 'value' on string ''` when migrating legacy items that stored `description` as a plain string. The migration now correctly converts string descriptions into the new object format `{ value: "..." }`.

2. **Added `coerceAttribNumber` helper and numeric normalization**  
   Introduced a new `coerceAttribNumber` helper function in the migration pipeline to properly normalize numeric actor fields. This helper:
   - Converts numeric strings (e.g. `"12"`) to actual numbers
   - Handles the special `'auto'` value
   - Is applied to:
     - Vehicle statistics
     - Character / NPC / Creature attributes: `hp`, `mp`, `lck`, `san`, `mov`, `build`, `armor`
   - Automatically computes `mov` and `build` values using the existing `movFromCharacteristics` and `buildFromCharacteristics` helpers when needed

These changes ensure that all migrated data uses proper numeric types, preventing type-related errors during import, calculations, and future migrations.

## Motivation and Context
- Users were experiencing repeated migration failures when importing actors (especially older exports or compendium content) containing legacy item data.
- Many numeric fields remained as strings after migration, causing downstream bugs in character sheets, combat, and automation.
- This PR improves migration robustness and data integrity when upgrading from older versions of the CoC7 system.

## Screenshots

<img width="654" height="594" alt="image" src="https://github.com/user-attachments/assets/9e9ee9f3-78ca-4d96-b7c7-b6d3f1b6378c" />

## Support Tested On
- [ ] FoundryVTT v12.
- [ ] FoundryVTT v13.
- [x] FoundryVTT v14.

## Types of Changes
- [ ] AI was not used in this pull request https://foundryvtt.com/article/ai-policy/
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Translation (list of missing keys can be found here https://github.com/Miskatonic-Investigative-Society/CoC7-FoundryVTT/blob/develop/.github/TRANSLATIONS.md)